### PR TITLE
website: fix broken link in nav sidebar

### DIFF
--- a/website/turbot.erb
+++ b/website/turbot.erb
@@ -66,7 +66,7 @@
                             <a href="#">Resources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
-                                    <a href="/docs/providers/turbot/r/garnt_activation.html">turbot_grant_activation</a>
+                                    <a href="/docs/providers/turbot/r/grant_activation.html">turbot_grant_activation</a>
                                 </li>
                             </ul>
                         </li>


### PR DESCRIPTION
Happens to all of us. 

Once merged, this fix should be cherry-picked to the stable-website branch, so hashicorp/terraform-website's CI will stop reporting errors for it. 