### PR TITLE
Update turbot_policy_setting to support passing an array of input queries for templateInput.

### DIFF
--- a/apiClient/types.go
+++ b/apiClient/types.go
@@ -94,7 +94,7 @@ type PolicySetting struct {
 	Default            bool
 	Precedence         string
 	Template           string
-	TemplateInput      string
+	TemplateInput      interface{}
 	Input              string
 	Note               string
 	ValidFromTimestamp string

--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -1,0 +1,28 @@
+package helpers
+
+import (
+	"fmt"
+	"github.com/go-yaml/yaml"
+)
+
+func ParseYamlString(value interface{}) (interface{}, error) {
+	var temp interface{}
+
+	s := SettingValueToString(value)
+	err := yaml.Unmarshal([]byte(s), &temp)
+	if err != nil {
+		return s, err
+	}
+	if temp == "" {
+		return value, nil
+	}
+	return temp, nil
+}
+
+// convert value to a string. If it is a complex type (object/array) then the diff calculation will use the value_source so the precise format is not critical
+func SettingValueToString(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", value)
+}

--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -3,19 +3,23 @@ package helpers
 import (
 	"fmt"
 	"github.com/go-yaml/yaml"
+	"reflect"
 )
 
 func ParseYamlString(value interface{}) (interface{}, error) {
 	var temp interface{}
 
 	s := InterfaceToString(value)
+
 	err := yaml.Unmarshal([]byte(s), &temp)
 	if err != nil {
 		return s, err
 	}
+
 	if temp == "" {
 		return value, nil
 	}
+
 	return temp, nil
 }
 
@@ -25,6 +29,21 @@ func InterfaceToString(value interface{}) string {
 		return ""
 	}
 	return fmt.Sprintf("%v", value)
+}
+
+func InterfaceToYaml(value interface{}) (string, error) {
+	if value == nil {
+		return "", nil
+	}
+	if res, ok := value.(string); ok {
+		return res, nil
+	}
+
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func YamlValuesAreEquivalent(yaml1, yaml2 string) (bool, error) {

--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -3,27 +3,26 @@ package helpers
 import (
 	"fmt"
 	"github.com/go-yaml/yaml"
-	"reflect"
 )
 
-func ParseYamlString(value interface{}) (interface{}, error) {
-	var temp interface{}
+// parse given string in YAML format
+func ParseYamlString(value string) (interface{}, error) {
+	var result interface{}
 
-	s := InterfaceToString(value)
-
-	err := yaml.Unmarshal([]byte(s), &temp)
+	err := yaml.Unmarshal([]byte(value), &result)
+	// returns value when unmarshal fails
 	if err != nil {
-		return s, err
+		return value, err
 	}
 
-	if temp == "" {
+	if result == "" {
 		return value, nil
 	}
 
-	return temp, nil
+	return result, nil
 }
 
-// convert value to a string. If it is a complex type (object/array) then the diff calculation will use the value_source so the precise format is not critical
+// convert value to a string.
 func InterfaceToString(value interface{}) string {
 	if value == nil {
 		return ""
@@ -31,7 +30,8 @@ func InterfaceToString(value interface{}) string {
 	return fmt.Sprintf("%v", value)
 }
 
-func InterfaceToYaml(value interface{}) (string, error) {
+// converts value to a string or YAML string
+func InterfaceToStringOrYaml(value interface{}) (string, error) {
 	if value == nil {
 		return "", nil
 	}
@@ -46,7 +46,8 @@ func InterfaceToYaml(value interface{}) (string, error) {
 	return string(data), nil
 }
 
-func YamlValuesAreEquivalent(yaml1, yaml2 string) (bool, error) {
+//implements a equal operation on 2 YAML strings
+func YamlStringsAreEqual(yaml1, yaml2 string) (bool, error) {
 	var yaml1intermediate, yaml2intermediate interface{}
 
 	if err := yaml.Unmarshal([]byte(yaml1), &yaml1intermediate); err != nil {
@@ -56,7 +57,20 @@ func YamlValuesAreEquivalent(yaml1, yaml2 string) (bool, error) {
 	if err := yaml.Unmarshal([]byte(yaml2), &yaml2intermediate); err != nil {
 		return false, fmt.Errorf("Error unmarshaling yaml string: %s", err)
 	}
-	if reflect.DeepEqual(yaml1intermediate, yaml2intermediate) {
+
+	s1, err := yaml.Marshal(yaml1intermediate)
+
+	if err != nil {
+		return false, fmt.Errorf("Error marshaling yaml string: %s", err)
+	}
+
+	s2, err := yaml.Marshal(yaml2intermediate)
+
+	if err != nil {
+		return false, fmt.Errorf("Error marshaling yaml string: %s", err)
+	}
+
+	if string(s1) == string(s2) {
 		return true, nil
 	}
 	return false, nil

--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -8,7 +8,7 @@ import (
 func ParseYamlString(value interface{}) (interface{}, error) {
 	var temp interface{}
 
-	s := SettingValueToString(value)
+	s := InterfaceToString(value)
 	err := yaml.Unmarshal([]byte(s), &temp)
 	if err != nil {
 		return s, err
@@ -20,9 +20,25 @@ func ParseYamlString(value interface{}) (interface{}, error) {
 }
 
 // convert value to a string. If it is a complex type (object/array) then the diff calculation will use the value_source so the precise format is not critical
-func SettingValueToString(value interface{}) string {
+func InterfaceToString(value interface{}) string {
 	if value == nil {
 		return ""
 	}
 	return fmt.Sprintf("%v", value)
+}
+
+func YamlValuesAreEquivalent(yaml1, yaml2 string) (bool, error) {
+	var yaml1intermediate, yaml2intermediate interface{}
+
+	if err := yaml.Unmarshal([]byte(yaml1), &yaml1intermediate); err != nil {
+		return false, fmt.Errorf("Error unmarshaling yaml string: %s", err)
+	}
+
+	if err := yaml.Unmarshal([]byte(yaml2), &yaml2intermediate); err != nil {
+		return false, fmt.Errorf("Error unmarshaling yaml string: %s", err)
+	}
+	if reflect.DeepEqual(yaml1intermediate, yaml2intermediate) {
+		return true, nil
+	}
+	return false, nil
 }

--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -30,7 +30,7 @@ func InterfaceToString(value interface{}) string {
 	return fmt.Sprintf("%v", value)
 }
 
-// converts value to a string or YAML string
+// if the value is already a string return it, otherwise convert to the YAML representation
 func InterfaceToStringOrYaml(value interface{}) (string, error) {
 	if value == nil {
 		return "", nil
@@ -46,7 +46,7 @@ func InterfaceToStringOrYaml(value interface{}) (string, error) {
 	return string(data), nil
 }
 
-//implements a equal operation on 2 YAML strings
+// implements a equal operation on 2 YAML strings, ignoring formatting differences
 func YamlStringsAreEqual(yaml1, yaml2 string) (bool, error) {
 	var yaml1intermediate, yaml2intermediate interface{}
 
@@ -59,13 +59,11 @@ func YamlStringsAreEqual(yaml1, yaml2 string) (bool, error) {
 	}
 
 	s1, err := yaml.Marshal(yaml1intermediate)
-
 	if err != nil {
 		return false, fmt.Errorf("Error marshaling yaml string: %s", err)
 	}
 
 	s2, err := yaml.Marshal(yaml2intermediate)
-
 	if err != nil {
 		return false, fmt.Errorf("Error marshaling yaml string: %s", err)
 	}

--- a/turbot/resource_turbot_policy_setting.go
+++ b/turbot/resource_turbot_policy_setting.go
@@ -140,8 +140,7 @@ func resourceTurbotPolicySettingCreate(d *schema.ResourceData, meta interface{})
 	input := mapFromResourceData(d, policySettingInputProperties)
 
 	if value, ok := d.GetOk("template_input"); ok {
-		// NOTE: ParseYamlString expects a string
-		// It does'nt validate input as valid YAML format, on error it returns value itself
+		// NOTE: ParseYamlString does'nt validate input as valid YAML format, on error it returns value
 		valueString := fmt.Sprintf("%v", value)
 		input["templateInput"], err = helpers.ParseYamlString(valueString)
 	}
@@ -247,8 +246,7 @@ func resourceTurbotPolicySettingUpdate(d *schema.ResourceData, meta interface{})
 
 	var err error
 	if value, ok := d.GetOk("template_input"); ok {
-		// NOTE: ParseYamlString expects a string
-		// It does'nt validate input as valid YAML format, on error it returns value itself
+		// NOTE: ParseYamlString doesn't validate input as valid YAML format, on error it just returns the value
 		valueString := fmt.Sprintf("%v", value)
 		input["templateInput"], err = helpers.ParseYamlString(valueString)
 	}

--- a/turbot/resource_turbot_policy_setting.go
+++ b/turbot/resource_turbot_policy_setting.go
@@ -140,7 +140,7 @@ func resourceTurbotPolicySettingCreate(d *schema.ResourceData, meta interface{})
 	input := mapFromResourceData(d, policySettingInputProperties)
 
 	if value, ok := d.GetOk("template_input"); ok {
-		// NOTE: ParseYamlString does'nt validate input as valid YAML format, on error it returns value
+		// NOTE: ParseYamlString doesn't validate input as valid YAML format, on error it returns value
 		valueString := fmt.Sprintf("%v", value)
 		input["templateInput"], err = helpers.ParseYamlString(valueString)
 	}

--- a/turbot/resource_turbot_policy_setting_test.go
+++ b/turbot/resource_turbot_policy_setting_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-//test suites
+// test suites
 func TestAccPolicySetting_String(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/turbot/resource_turbot_policy_setting_test.go
+++ b/turbot/resource_turbot_policy_setting_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// test suites
+//test suites
 func TestAccPolicySetting_String(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -224,11 +224,16 @@ func TestAccPolicySetting_TemplateInputJsonValue(t *testing.T) {
 		CheckDestroy: testAccCheckPolicySettingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPolicySettingJsonTemplateInput(),
+				Config: testAccPolicySettingJsonTemplateInput("Name"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPolicySettingExists("turbot_policy_setting.test_policy"),
-					resource.TestCheckResourceAttr(
-						"turbot_policy_setting.test_policy", "template_input", "[\n  \"{\\n \\titem: bucket {\\n   \\tName\\n \\t}\\n}\\n\",\n  \"{\\n \\tresources(filter: \\\"$.DistributionConfig.Origins.Items.*.DomainName:'{{$.item.Name}}.s3.amazonaws.com' resourceTypeId:tmod:@turbot/aws-cloudfront#/resource/types/cloudFront\\\") {\\n   \\titems {\\n   \\t  Id: get(path:\\\"Id\\\")\\n   \\t}\\n \\t}\\n}\\n\"\n]\n"),
+					resource.TestCheckResourceAttr("turbot_policy_setting.test_policy", "precedence", "REQUIRED"),
+				),
+			},
+			{
+				Config: testAccPolicySettingYamlTemplateInput("test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicySettingExists("turbot_policy_setting.test_policy"),
 					resource.TestCheckResourceAttr("turbot_policy_setting.test_policy", "precedence", "REQUIRED"),
 				),
 			},
@@ -242,11 +247,16 @@ func TestAccPolicySetting_TemplateInputYamlValue(t *testing.T) {
 		CheckDestroy: testAccCheckPolicySettingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPolicySettingYamlTemplateInput(),
+				Config: testAccPolicySettingYamlTemplateInput("Name"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPolicySettingExists("turbot_policy_setting.test_policy"),
-					resource.TestCheckResourceAttr(
-						"turbot_policy_setting.test_policy", "template_input", "- | \n {\n  \titem: bucket {\n    \tName\n  \t}\n }\n- | \n {\n  \tresources(filter: \"$.DistributionConfig.Origins.Items.*.DomainName:'{{$.item.Name}}.s3.amazonaws.com' resourceTypeId:tmod:@turbot/aws-cloudfront#/resource/types/cloudFront\") {\n    \titems {\n    \t  Id: get(path:\"Id\")\n    \t}\n  \t}\n }\n"),
+					resource.TestCheckResourceAttr("turbot_policy_setting.test_policy", "precedence", "REQUIRED"),
+				),
+			},
+			{
+				Config: testAccPolicySettingYamlTemplateInput("test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicySettingExists("turbot_policy_setting.test_policy"),
 					resource.TestCheckResourceAttr("turbot_policy_setting.test_policy", "precedence", "REQUIRED"),
 				),
 			},
@@ -261,11 +271,16 @@ func TestAccPolicySetting_TemplateInputStringValue(t *testing.T) {
 		CheckDestroy: testAccCheckPolicySettingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPolicySettingStringTemplateInput(),
+				Config: testAccPolicySettingStringTemplateInput("Name"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPolicySettingExists("turbot_policy_setting.test_policy"),
-					resource.TestCheckResourceAttr(
-						"turbot_policy_setting.test_policy", "template_input", "{\n    item: bucket {\n      Name\n    }\n}\n"),
+					resource.TestCheckResourceAttr("turbot_policy_setting.test_policy", "precedence", "REQUIRED"),
+				),
+			},
+			{
+				Config: testAccPolicySettingStringTemplateInput("test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicySettingExists("turbot_policy_setting.test_policy"),
 					resource.TestCheckResourceAttr("turbot_policy_setting.test_policy", "precedence", "REQUIRED"),
 				),
 			},
@@ -281,7 +296,7 @@ var secretPolicyType = "tmod:@turbot/provider-policy-test#/policy/types/secretPo
 var stringPolicyTemplate = "{% if $.account.Id == '650022101893' %}Skip{% else %}'Check: Configured'{% endif %}"
 var stringPolicyTemplateInput = "{ account{ Id } }"
 
-func testAccPolicySettingStringTemplateInput() string {
+func testAccPolicySettingStringTemplateInput(templateInput string) string {
 	return fmt.Sprintf(`
 resource "turbot_policy_setting" "test_policy" {
   	resource    = "tmod:@turbot/turbot#/"
@@ -289,34 +304,34 @@ resource "turbot_policy_setting" "test_policy" {
   	template_input = <<EOF
 {
     item: bucket {
-      Name
+      %s
     }
 }
 EOF
 	template =  "Testing"
 	precedence = "REQUIRED"
 }
-`)
+`, templateInput)
 }
 
-func testAccPolicySettingJsonTemplateInput() string {
+func testAccPolicySettingJsonTemplateInput(templateInput string) string {
 	return fmt.Sprintf(`
 resource "turbot_policy_setting" "test_policy" {
   	resource    = "tmod:@turbot/turbot#/"
   	type = "tmod:@turbot/aws-s3#/policy/types/bucketApprovedUsage"
   	template_input = <<EOF
 [
-  "{\n \titem: bucket {\n   \tName\n \t}\n}\n",
+  "{\n \titem: bucket {\n   \t%s\n \t}\n}\n",
   "{\n \tresources(filter: \"$.DistributionConfig.Origins.Items.*.DomainName:'{{$.item.Name}}.s3.amazonaws.com' resourceTypeId:tmod:@turbot/aws-cloudfront#/resource/types/cloudFront\") {\n   \titems {\n   \t  Id: get(path:\"Id\")\n   \t}\n \t}\n}\n"
 ]
 EOF
 	template =  "Testing"
 	precedence = "REQUIRED"
 }
-`)
+`, templateInput)
 }
 
-func testAccPolicySettingYamlTemplateInput() string {
+func testAccPolicySettingYamlTemplateInput(templateInput string) string {
 	return fmt.Sprintf(`
 resource "turbot_policy_setting" "test_policy" {
   	resource    = "tmod:@turbot/turbot#/"
@@ -325,7 +340,7 @@ resource "turbot_policy_setting" "test_policy" {
 - | 
  {
   	item: bucket {
-    	Name
+    	%s
   	}
  }
 - | 
@@ -340,7 +355,7 @@ EOF
 	template =  "Testing"
 	precedence = "REQUIRED"
 }
-`)
+`, templateInput)
 }
 
 func testAccPolicySettingPrecedenceAttr(value string) string {

--- a/website/docs/r/policy_setting.html.markdown
+++ b/website/docs/r/policy_setting.html.markdown
@@ -75,8 +75,8 @@ The following arguments are supported:
 - `resource` - (Required) The `aka` of the resource.
 - `note` - (Optional) Additional notes, if desired.
 - `precedence` - (Optional) Determines whether the policy setting should be `required` or `recommended`. Defaults to `required`.
-- `template` - (Optional) Nunjucks template that is used to render the policy, it can be either in `YAML`, `JSON` or `string` representation.
-- `template_input` - (Optional) A GraphQL query required as the input for the `template`.
+- `template` - (Optional) Nunjucks template that is used to render the policy.
+- `template_input` - (Optional) A GraphQL query as a `string` or array of GraphQL queries in `YAML` format required as the input for the `template` .
 - `valid_from_timestamp` - (Optional) The start of a specific time period for which the policy setting is valid.
 - `valid_to_timestamp` - (Optional) The expiration date of a policy value.
 - `value` - (Optional) Value of the policy. This could either be the value of the setting or a `yaml` string representing the setting.

--- a/website/docs/r/policy_setting.html.markdown
+++ b/website/docs/r/policy_setting.html.markdown
@@ -13,7 +13,7 @@ The `Turbot Policy Setting` resource adds support for setting policies for resou
 
 ## Example Usage
 
-**Creating Your First Folder**
+**Setting Your First Policy**
 
 ```hcl
 resource "turbot_folder" "test" {
@@ -21,11 +21,6 @@ resource "turbot_folder" "test" {
   title           = "My Folder"
   description     = "My first test folder"
 }
-```
-
-**Setting Your First Policy**
-
-```hcl
 resource "turbot_policy_setting" "test_policy" {
   resource    = turbot_folder.parent.id
   type        = "tmod:@turbot/turbot-iam#/policy/types/permissions"
@@ -44,6 +39,34 @@ resource "turbot_policy_setting" "template_policy" {
 }
 ```
 
+**Setting Your Calculated Policy Using Nunjucks Template **
+
+```hcl
+resource "turbot_policy_setting" "test_policy" {
+  	resource    = "tmod:@turbot/turbot#/"
+  	type = "tmod:@turbot/aws-s3#/policy/types/bucketApprovedUsage"
+  	template_input = <<EOF
+- | 
+ {
+  	item: bucket {
+    	Name
+  	}
+ }
+- | 
+ {
+  	resources(filter: "$.DistributionConfig.Origins.Items.*.DomainName:'{{$.item.Name}}.s3.amazonaws.com' resourceTypeId:tmod:@turbot/aws-cloudfront#/resource/types/cloudFront") {
+    	items {
+    	  Id: get(path:"Id")
+    	}
+  	}
+ }
+EOF
+	template =  "{% if $.Id == '112233445566' %}Skip{% else %}'Done'{% endif %}"
+	precedence = "REQUIRED"
+}
+
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -52,7 +75,7 @@ The following arguments are supported:
 - `resource` - (Required) The `aka` of the resource.
 - `note` - (Optional) Additional notes, if desired.
 - `precedence` - (Optional) Determines whether the policy setting should be `required` or `recommended`. Defaults to `required`.
-- `template` - (Optional) Nunjucks template that is used to render the policy.
+- `template` - (Optional) Nunjucks template that is used to render the policy, it can be either in `YAML`, `JSON` or `string` representation.
 - `template_input` - (Optional) A GraphQL query required as the input for the `template`.
 - `valid_from_timestamp` - (Optional) The start of a specific time period for which the policy setting is valid.
 - `valid_to_timestamp` - (Optional) The expiration date of a policy value.

--- a/website/docs/r/policy_setting.html.markdown
+++ b/website/docs/r/policy_setting.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 - `note` - (Optional) Additional notes, if desired.
 - `precedence` - (Optional) Determines whether the policy setting should be `required` or `recommended`. Defaults to `required`.
 - `template` - (Optional) Nunjucks template that is used to render the policy.
-- `template_input` - (Optional) A GraphQL query as a `string` or array of GraphQL queries in `YAML` format required as the input for the `template` .
+- `template_input` - (Optional) A GraphQL query as a `string` or array of GraphQL queries in `YAML` format. The GraphQL output is used as the render context when rendering the `template`
 - `valid_from_timestamp` - (Optional) The start of a specific time period for which the policy setting is valid.
 - `valid_to_timestamp` - (Optional) The expiration date of a policy value.
 - `value` - (Optional) Value of the policy. This could either be the value of the setting or a `yaml` string representing the setting.


### PR DESCRIPTION
 Closes #11

Acceptance Test - 
```
=== RUN   TestAccPolicySetting_String
--- PASS: TestAccPolicySetting_String (30.09s)
=== RUN   TestAccPolicySetting_Int
--- PASS: TestAccPolicySetting_Int (19.64s)
=== RUN   TestAccPolicySetting_Array
--- PASS: TestAccPolicySetting_Array (15.09s)
=== RUN   TestAccPolicySetting_ArrayEncrypted
--- PASS: TestAccPolicySetting_ArrayEncrypted (13.58s)
=== RUN   TestAccPolicySetting_SecretUnencrypted
--- PASS: TestAccPolicySetting_SecretUnencrypted (8.22s)
=== RUN   TestAccPolicySetting_SecretEncrypted
--- PASS: TestAccPolicySetting_SecretEncrypted (8.59s)
=== RUN   TestAccPolicySetting_Precedence_Value_Check
--- PASS: TestAccPolicySetting_Precedence_Value_Check (12.92s)
=== RUN   TestAccPolicySetting_TemplateInputJsonValue
--- PASS: TestAccPolicySetting_TemplateInputJsonValue (8.04s)
=== RUN   TestAccPolicySetting_TemplateInputYamlValue
--- PASS: TestAccPolicySetting_TemplateInputYamlValue (8.50s)
=== RUN   TestAccPolicySetting_TemplateInputStringValue
--- PASS: TestAccPolicySetting_TemplateInputStringValue (8.01s)
PASS
```