### PR TITLE
Update `turbot_smart_folder` to make `parent` arg optional. Closes #169

### DIFF
--- a/turbot/resource_turbot_smart_folder.go
+++ b/turbot/resource_turbot_smart_folder.go
@@ -29,10 +29,11 @@ func resourceTurbotSmartFolder() *schema.Resource {
 			//aka of the parent resource
 			"parent": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				// when doing a diff, the state file will contain the id of the parent but the config contains the aka,
 				// so we need custom diff code
 				DiffSuppressFunc: suppressIfAkaMatches("parent_akas"),
+				Default:          "tmod:@turbot/turbot#/",
 			},
 			//when doing a read, fetch the parent akas to use in suppressIfAkaMatches
 			"parent_akas": {


### PR DESCRIPTION
```
resource "turbot_smart_folder" "folder" {
  title       = "My smart folder 123467"
  description = "hello world"
}
```

![image](https://github.com/user-attachments/assets/5e9c7f5c-9a0f-43d8-bb2b-9a29a1ec6957)

![image](https://github.com/user-attachments/assets/3d326e69-849f-409f-b109-7a5c56b44009)
