### PR TITLE
Add precheck to validate policy type existence before creation. Closes #214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.12.3 (TBD)
+
+BUG FIXES:
+
+* There was an issue in the policySetting resource where the log message was not correctly formed when attempting to create policy settings for non-existent or uninstalled policy types. The log message is now more informative and precise. ([#214](https://github.com/turbot/terraform-provider-turbot/issues/214))
+
 ## 1.12.2 (May 12, 2025)
 
 ENHANCEMENTS:

--- a/apiClient/policy_type.go
+++ b/apiClient/policy_type.go
@@ -1,0 +1,18 @@
+package apiClient
+
+func (client *Client) FindPolicyType(policyTypeUri string) (PolicyType, error) {
+	responseData := &FindPolicyTypeResponse{}
+
+	query := findPolicyTypeQuery(policyTypeUri)
+
+	// execute api call
+	if err := client.doRequest(query, nil, &responseData); err != nil {
+		return PolicyType{}, client.handleReadError(err, policyTypeUri, "policy type")
+	}
+
+	if len(responseData.PolicyTypes.Items) > 0 {
+		return responseData.PolicyTypes.Items[0], nil
+	}
+
+	return PolicyType{}, nil
+}

--- a/apiClient/queries.go
+++ b/apiClient/queries.go
@@ -195,7 +195,7 @@ func readPolicyValueQuery(policyTypeUri string, resourceId string) string {
 
 func findPolicyTypeQuery(policyTypeUri string) string {
 	return fmt.Sprintf(`{
-  policySettings: policyTypes(filter: "policyTypeId:%s level:self") {
+  policyTypes: policyTypes(filter: "policyTypeId:%s level:self") {
     items {
 		modUri
 		turbot {

--- a/apiClient/queries.go
+++ b/apiClient/queries.go
@@ -193,6 +193,20 @@ func readPolicyValueQuery(policyTypeUri string, resourceId string) string {
 `, policyTypeUri, resourceId)
 }
 
+func findPolicyTypeQuery(policyTypeUri string) string {
+	return fmt.Sprintf(`{
+  policySettings: policyTypes(filter: "policyTypeId:%s level:self") {
+    items {
+		modUri
+		turbot {
+			id
+		}
+    }
+  }
+}
+`, policyTypeUri)
+}
+
 // watch
 func createWatchMutation() string {
 	return fmt.Sprintf(`mutation CreateWatch($input: CreateWatchInput!) {

--- a/apiClient/types.go
+++ b/apiClient/types.go
@@ -172,6 +172,21 @@ type PolicyValue struct {
 	Turbot     TurbotPolicyMetadata
 }
 
+// PolicyType
+type PolicyTypeResponse struct {
+	PolicyType PolicyType
+}
+
+type FindPolicyTypeResponse struct {
+	PolicyTypes struct {
+		Items []PolicyType
+	}
+}
+type PolicyType struct {
+	ModUri string
+	Turbot TurbotPolicyMetadata
+}
+
 // Mod
 type InstallModResponse struct {
 	Mod InstallModData

--- a/turbot/resource_turbot_policy_setting.go
+++ b/turbot/resource_turbot_policy_setting.go
@@ -123,7 +123,16 @@ func resourceTurbotPolicySettingCreate(d *schema.ResourceData, meta interface{})
 	policyTypeUri := d.Get("type").(string)
 	resourceAka := d.Get("resource").(string)
 
-	// first check if the folder exists - search by parent and foldere title
+	// check if the policy type is installed -- is the mod installed?
+	policyType, err := client.FindPolicyType(policyTypeUri)
+	if err != nil {
+		return err
+	}
+	if policyType.ModUri == "" {
+		return fmt.Errorf("policy type %s not found. Is the mod installed?", policyTypeUri)
+	}
+
+	// first check if the folder exists - search by parent and folder title
 	existingSetting, err := client.FindPolicySetting(policyTypeUri, resourceAka)
 	if err != nil {
 		return err

--- a/turbot/resource_turbot_policy_setting.go
+++ b/turbot/resource_turbot_policy_setting.go
@@ -132,7 +132,7 @@ func resourceTurbotPolicySettingCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("policy type %s not found. Is the mod installed?", policyTypeUri)
 	}
 
-	// first check if the folder exists - search by parent and folder title
+	// check if the folder exists - search by parent and folder title
 	existingSetting, err := client.FindPolicySetting(policyTypeUri, resourceAka)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Previous behavior
```sh
Terraform will perform the following actions:

  # turbot_policy_setting.aws_acm_certificate_approved will be created
  + resource "turbot_policy_setting" "aws_acm_certificate_approved" {
      + id                           = (known after apply)
      + precedence                   = "REQUIRED"
      + resource                     = "350804102494366"
      + resource_akas                = (known after apply)
      + type                         = "tmod:@turbot/aws-acm#/policy/types/certificateApproved"
      + value                        = "Skip"
      + value_key_fingerprint        = (known after apply)
      + value_source                 = (sensitive value)
      + value_source_key_fingerprint = (known after apply)
      + value_source_used            = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
turbot_policy_setting.aws_acm_certificate_approved: Creating...
╷
│ Error: error creating policy setting: parent resource not found: %!s(<nil>)
│ 
│   with turbot_policy_setting.aws_acm_certificate_approved,
│   on main.tf line 96, in resource "turbot_policy_setting" "aws_acm_certificate_approved":
│   96: resource "turbot_policy_setting" "aws_acm_certificate_approved" {
```

### Current behavior
```sh
Terraform will perform the following actions:

  # turbot_policy_setting.aws_acm_certificate_approved will be created
  + resource "turbot_policy_setting" "aws_acm_certificate_approved" {
      + id                           = (known after apply)
      + precedence                   = "REQUIRED"
      + resource                     = "350804102494366"
      + resource_akas                = (known after apply)
      + type                         = "tmod:@turbot/aws-acm#/policy/types/certificateApproved"
      + value                        = "Skip"
      + value_key_fingerprint        = (known after apply)
      + value_source                 = (sensitive value)
      + value_source_key_fingerprint = (known after apply)
      + value_source_used            = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
turbot_policy_setting.aws_acm_certificate_approved: Creating...
╷
│ Error: policy type tmod:@turbot/aws-acm#/policy/types/certificateApproved not found. Is the mod installed?
│ 
│   with turbot_policy_setting.aws_acm_certificate_approved,
│   on main.tf line 96, in resource "turbot_policy_setting" "aws_acm_certificate_approved":
│   96: resource "turbot_policy_setting" "aws_acm_certificate_approved" {
```