### PR TITLE
fix: ensure SAML certificate updates via Terraform are applied correctly. Closes #216

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ BUG FIXES:
 
 * There was an issue in the policySetting resource where the log message was not correctly formed when attempting to create policy settings for non-existent or uninstalled policy types. The log message is now more informative and precise. ([#214](https://github.com/turbot/terraform-provider-turbot/issues/214))
 
+* SAML certificate updates via Terraform applied successfully but didn't persist in the backend. These updates are now processed correctly. ([#216](https://github.com/turbot/terraform-provider-turbot/issues/216))
+
 ## 1.12.2 (May 12, 2025)
 
 ENHANCEMENTS:

--- a/turbot/resource_turbot_saml_directory.go
+++ b/turbot/resource_turbot_saml_directory.go
@@ -1,11 +1,12 @@
 package turbot
 
 import (
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/turbot/terraform-provider-turbot/apiClient"
 	"github.com/turbot/terraform-provider-turbot/errors"
 	"github.com/turbot/terraform-provider-turbot/helpers"
-	"strings"
 )
 
 // input properties which must be passed to a create/update call
@@ -14,7 +15,7 @@ var samlDirectoryInputProperties = []interface{}{"title", "description", "status
 // exclude properties from input map to make a create call
 func getSamlDirectoryProperties() []interface{} {
 	excludedProperties := []string{"group_id_template", "tags", "profile_id_template"}
-	return helpers.RemoveProperties(localDirectoryInputProperties, excludedProperties)
+	return helpers.RemoveProperties(samlDirectoryInputProperties, excludedProperties)
 }
 
 func resourceTurbotSamlDirectory() *schema.Resource {


### PR DESCRIPTION
#### Terraform Configuration

```hcl
variable "pingone_certificate" {
  description = "The certificate for PingOne SAML integration"
  type        = string
  sensitive   = true
}

variable "pingone_issuer_url" {
  description = "The issuer URL for PingOne SAML integration"
  type        = string
}

resource "turbot_saml_directory" "ping_one_login" {
    parent              = "tmod:@turbot/turbot#/"
    title               = "PingOne Login"
    profile_id_template = "pingid.{{profile.email}}"
    description         = "PingOne login for Turbot."
    entry_point         = "https://login.abcdef.com/saml20/idp/sso"
    certificate         = var.pingone_certificate
    issuer              = var.pingone_issuer_url
}
```

🛠️ Plan Command & Output

#### Command

```sh
terraform plan -var="pingone_certificate=hello_world" -var="pingone_issuer_url=https://pikachu-turbot.spongebob.turbot.io/"
```

#### Output

```sh
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # turbot_saml_directory.ping_one_login will be created
  + resource "turbot_saml_directory" "ping_one_login" {
      + allow_group_syncing     = false
      + allow_idp_initiated_sso = false
      + certificate             = (sensitive value)
      + description             = "PingOne login for Turbot."
      + directory_type          = (known after apply)
      + entry_point             = "https://login.abcdef.com/saml20/idp/sso"
      + id                      = (known after apply)
      + issuer                  = "https://pikachu-turbot.spongebob.turbot.io/"
      + name_id_format          = "UNSPECIFIED"
      + parent                  = "tmod:@turbot/turbot#/"
      + parent_akas             = (known after apply)
      + profile_id_template     = "pingid.{{profile.email}}"
      + status                  = (known after apply)
      + title                   = "PingOne Login"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

🚀 Apply Command & Output

#### Command

```sh
terraform apply -var="pingone_certificate=hello_world" -var="pingone_issuer_url=https://pikachu-turbot.spongebob.turbot.io/" -auto-approve
```

#### Output

```sh
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # turbot_saml_directory.ping_one_login will be created
  + resource "turbot_saml_directory" "ping_one_login" {
      + allow_group_syncing     = false
      + allow_idp_initiated_sso = false
      + certificate             = (sensitive value)
      + description             = "PingOne login for Turbot."
      + directory_type          = (known after apply)
      + entry_point             = "https://login.abcdef.com/saml20/idp/sso"
      + id                      = (known after apply)
      + issuer                  = "https://pikachu-turbot.spongebob.turbot.io/"
      + name_id_format          = "UNSPECIFIED"
      + parent                  = "tmod:@turbot/turbot#/"
      + parent_akas             = (known after apply)
      + profile_id_template     = "pingid.{{profile.email}}"
      + status                  = (known after apply)
      + title                   = "PingOne Login"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
turbot_saml_directory.ping_one_login: Creating...
turbot_saml_directory.ping_one_login: Creation complete after 1s [id=357194261250056]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

#### UI

![image](https://github.com/user-attachments/assets/6543fd72-5ba4-4457-9465-2536e9c87653)


### Update Certificate

#### Command

```sh
terraform apply -var="pingone_certificate=-----BEGIN CERTIFICATE-----\nxxxxxxxxxxxx\n-----END CERTIFICATE-----" -var="pingone_issuer_url=https://pikachu-turbot.spongebob.turbot.io/" -auto-approve
```

#### Output

```sh
turbot_saml_directory.ping_one_login: Refreshing state... [id=357194261250056]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # turbot_saml_directory.ping_one_login will be updated in-place
  ~ resource "turbot_saml_directory" "ping_one_login" {
      ~ certificate              = (sensitive value)
        id                       = "357194261250056"
        tags                     = {}
        # (16 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
turbot_saml_directory.ping_one_login: Modifying... [id=357194261250056]
turbot_saml_directory.ping_one_login: Modifications complete after 1s [id=357194261250056]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

#### UI

![image](https://github.com/user-attachments/assets/bce90557-8927-43c3-87a5-ba9cd5a31bd6)
