### PR TITLE
Fix: Update Turbot File resource to send content as-is without setting removed keys to null. Closes #424

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.12.5 (TBD)
+
+BUG FIXES:
+
+* Fixed an issue in the `turbot_file` resource where removed keys in the content field were incorrectly sent as `"key": null` in the update payload. The provider now sends the content exactly as specified in the Terraform configuration, ensuring that only the intended keys appear in the Turbot console.. ([#224](https://github.com/turbot/terraform-provider-turbot/issues/224))
+
 ## 1.12.4 (July 23, 2025)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* Fixed an issue in the `turbot_file` resource where removed keys in the content field were incorrectly sent as `"key": null` in the update payload. The provider now sends the content exactly as specified in the Terraform configuration, ensuring that only the intended keys appear in the Turbot console.. ([#224](https://github.com/turbot/terraform-provider-turbot/issues/224))
+* Fixed an issue in the `turbot_file` resource where removed keys in the content field were incorrectly sent as `"key": null` in the update payload. The provider now sends the content exactly as specified in the Terraform configuration, ensuring that only the intended keys appear in the Turbot console. ([#224](https://github.com/turbot/terraform-provider-turbot/issues/224))
 
 ## 1.12.4 (July 23, 2025)
 


### PR DESCRIPTION
Previously, when updating the `content` field of a `turbot_file` resource, the provider would set any keys removed from the new content to `null` in the update payload. This resulted in keys being displayed as `"key": null` in the Turbot console, rather than being omitted entirely.

With this change, the provider now sends the `content` exactly as specified in the Terraform configuration, without setting removed keys to `null`. This ensures that the Turbot File resource reflects only the keys present in the latest configuration, providing a more intuitive and expected behavior for users.

- Replaced the use of `buildInputDataMap` with direct parsing of the new `content` JSON.
- The update payload now mirrors the user-provided content exactly.

### Creating the `turbot_file` resource
```hcl
resource "turbot_file" "turbot_file_foo_bar" {
  parent      = "tmod:@turbot/turbot#/"
  title       = "Turbot File Foo Bar"
  description = "AWS Account Budget"
  akas        = ["turbot_file_foo_bar"]
  content     = <<-EOT
    {
      "foo": "bar"
    }
    EOT
}
```
```shell
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # turbot_file.turbot_file_foo_bar will be created
  + resource "turbot_file" "turbot_file_foo_bar" {
      + akas        = [
          + "turbot_file_foo_bar",
        ]
      + content     = jsonencode(
            {
              + foo = "bar"
            }
        )
      + description = "AWS Account Budget"
      + id          = (known after apply)
      + parent      = "tmod:@turbot/turbot#/"
      + parent_akas = (known after apply)
      + title       = "Turbot File Foo Bar"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
turbot_file.turbot_file_foo_bar: Creating...
turbot_file.turbot_file_foo_bar: Creation complete after 1s [id=359758620192852]
```

### Updating the content
```hcl
resource "turbot_file" "turbot_file_foo_bar" {
  parent      = "tmod:@turbot/turbot#/"
  title       = "Turbot File Foo Bar"
  description = "AWS Account Budget"
  akas        = ["turbot_file_foo_bar"]
  content     = <<-EOT
    {
      "timon": "pumbaa"
    }
    EOT
}
```
```shell
turbot_file.turbot_file_foo_bar: Refreshing state... [id=359758620192852]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # turbot_file.turbot_file_foo_bar will be updated in-place
  ~ resource "turbot_file" "turbot_file_foo_bar" {
      ~ content     = jsonencode(
          ~ {
              - foo   = "bar"
              + timon = "pumbaa"
            }
        )
        id          = "359758620192852"
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
turbot_file.turbot_file_foo_bar: Modifying... [id=359758620192852]
turbot_file.turbot_file_foo_bar: Modifications complete after 0s [id=359758620192852]
```

### Updating a typo in the content
```hcl
resource "turbot_file" "turbot_file_foo_bar" {
  parent      = "tmod:@turbot/turbot#/"
  title       = "Turbot File Foo Bar"
  description = "AWS Account Budget"
  akas        = ["turbot_file_foo_bar"]
  content     = <<-EOT
    {
      "timon": "pumba"
    }
    EOT
}
```
```hcl
turbot_file.turbot_file_foo_bar: Refreshing state... [id=359758620192852]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # turbot_file.turbot_file_foo_bar will be updated in-place
  ~ resource "turbot_file" "turbot_file_foo_bar" {
      ~ content     = jsonencode(
          ~ {
              ~ timon = "pumbaa" -> "pumba"
            }
        )
        id          = "359758620192852"
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
turbot_file.turbot_file_foo_bar: Modifying... [id=359758620192852]
turbot_file.turbot_file_foo_bar: Modifications complete after 1s [id=359758620192852]
```

<img width="1920" height="773" alt="image" src="https://github.com/user-attachments/assets/6ccfc7b0-cf3f-4911-92fb-4557bc296982" />
