### PR TITLE
Harden GitHub Actions: pin actions to SHAs and set explicit permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   test:
     env:
@@ -25,12 +28,12 @@ jobs:
           git config --global core.eol lf
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: 1.22
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Vet
         run: make vet


### PR DESCRIPTION
## Harden GitHub Actions workflows

- Pin all action/workflow references to immutable commit SHAs
- Add explicit minimal `permissions` blocks

**Why**: Prevents supply chain attacks where a tag could be moved to point to malicious code. Explicit permissions reduce blast radius if a workflow is compromised.