### PR TITLE
fix: support AKA strings in policy_pack and smart_folder attachment fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.13.3 (Unreleased)
+
+BUG FIXES:
+
+* `resource/turbot_policy_pack_attachment`: Fixed an error where passing an AKA string (e.g. `enforce_gcp_storage_bucket_policy_trusted_access`) for `policy_pack` caused `"smart folder ids not eligible for attachment"`. The AKA is now resolved to a numeric Turbot ID before calling the mutation. Also suppresses spurious plan diffs when the config uses an AKA but state holds the resolved numeric ID. ([#241](https://github.com/turbot/terraform-provider-turbot/pull/241))
+* `resource/turbot_smart_folder_attachment`: Same fix applied — AKA strings in `smart_folder` are now resolved to numeric IDs before attachment. ([#241](https://github.com/turbot/terraform-provider-turbot/pull/241))
+
 ## 1.13.2 (February 12, 2026)
 
 DOCUMENTATION:

--- a/turbot/resource_turbot_policy_pack_attachment.go
+++ b/turbot/resource_turbot_policy_pack_attachment.go
@@ -80,13 +80,16 @@ func resourceTurbotPolicyPackAttachmentCreate(d *schema.ResourceData, meta inter
 
 	// Resolve the policy_pack AKA or ID to its numeric Turbot ID.
 	// The attachSmartFolders mutation requires numeric IDs — AKA strings cause "not eligible for attachment" errors.
-	// ReadResource uses a typed turbot { id } query which correctly populates Turbot.Id,
-	// unlike ReadSmartFolder which uses get(path:"turbot") and does not parse Id reliably.
+	// ReadSmartFolder unmarshals directly to a typed struct and does not reliably populate Turbot.Id;
+	// ReadResource decodes via mapstructure from interface{} which handles it correctly.
 	policyPackResource, err := client.ReadResource(policyPack, nil)
 	if err != nil {
 		return fmt.Errorf("error reading policy pack %q: %s", policyPack, err.Error())
 	}
 	resolvedPolicyPackId := policyPackResource.Turbot.Id
+	if resolvedPolicyPackId == "" {
+		return fmt.Errorf("policy pack %q resolved to an empty ID", policyPack)
+	}
 
 	input := map[string]interface{}{
 		"resource":     resource,
@@ -102,10 +105,12 @@ func resourceTurbotPolicyPackAttachmentCreate(d *schema.ResourceData, meta inter
 	if err := storeAkas(resource, "resource_akas", d, meta); err != nil {
 		return err
 	}
-	// Store policy pack AKAs for DiffSuppressFunc on the policy_pack field
-	if err := storeAkas(resolvedPolicyPackId, "policy_pack_akas", d, meta); err != nil {
-		return err
+	// Reuse AKAs from the already-fetched policy pack resource to avoid a second round-trip
+	policyPackAkas := policyPackResource.Turbot.Akas
+	if policyPackAkas == nil {
+		policyPackAkas = []string{resolvedPolicyPackId}
 	}
+	d.Set("policy_pack_akas", policyPackAkas)
 
 	// Always store the resolved numeric ID in state and the state ID so parsePolicyPackId
 	// (which splits on the first underscore) works correctly for all input formats.

--- a/turbot/resource_turbot_policy_pack_attachment.go
+++ b/turbot/resource_turbot_policy_pack_attachment.go
@@ -8,11 +8,6 @@ import (
 	"github.com/turbot/terraform-provider-turbot/apiClient"
 )
 
-var policyPackAttachProperties = map[string]string{
-	"resource":    "resource",
-	"policy_pack": "smartFolders",
-}
-
 func resourceTurbotPolicyPackAttachment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTurbotPolicyPackAttachmentCreate,
@@ -30,11 +25,21 @@ func resourceTurbotPolicyPackAttachment() *schema.Resource {
 				DiffSuppressFunc: suppressIfAkaMatches("resource_akas"),
 			},
 			"policy_pack": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppressIfAkaMatches("policy_pack_akas"),
 			},
 			"resource_akas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			// Stores the policy pack's AKAs so suppressIfAkaMatches can suppress diffs
+			// when the user provides an AKA but the state holds the resolved numeric ID.
+			"policy_pack_akas": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Schema{
@@ -72,22 +77,41 @@ func resourceTurbotPolicyPackAttachmentCreate(d *schema.ResourceData, meta inter
 	client := meta.(*apiClient.Client)
 	resource := d.Get("resource").(string)
 	policyPack := d.Get("policy_pack").(string)
-	input := mapFromResourceDataWithPropertyMap(d, policyPackAttachProperties)
 
-	_, err := client.CreateSmartFolderAttachment(input)
+	// Resolve the policy_pack AKA or ID to its numeric Turbot ID.
+	// The attachSmartFolders mutation requires numeric IDs — AKA strings cause "not eligible for attachment" errors.
+	// ReadResource uses a typed turbot { id } query which correctly populates Turbot.Id,
+	// unlike ReadSmartFolder which uses get(path:"turbot") and does not parse Id reliably.
+	policyPackResource, err := client.ReadResource(policyPack, nil)
+	if err != nil {
+		return fmt.Errorf("error reading policy pack %q: %s", policyPack, err.Error())
+	}
+	resolvedPolicyPackId := policyPackResource.Turbot.Id
+
+	input := map[string]interface{}{
+		"resource":     resource,
+		"smartFolders": resolvedPolicyPackId,
+	}
+
+	_, err = client.CreateSmartFolderAttachment(input)
 	if err != nil {
 		return err
 	}
 
-	// set resource_akas property by loading resource and fetching the akas
+	// Store resource AKAs for DiffSuppressFunc on the resource field
 	if err := storeAkas(resource, "resource_akas", d, meta); err != nil {
 		return err
 	}
-	// assign the id
-	var stateId = buildPolicyPackId(policyPack, resource)
-	d.SetId(stateId)
+	// Store policy pack AKAs for DiffSuppressFunc on the policy_pack field
+	if err := storeAkas(resolvedPolicyPackId, "policy_pack_akas", d, meta); err != nil {
+		return err
+	}
+
+	// Always store the resolved numeric ID in state and the state ID so parsePolicyPackId
+	// (which splits on the first underscore) works correctly for all input formats.
+	d.SetId(buildPolicyPackId(resolvedPolicyPackId, resource))
 	d.Set("resource", resource)
-	d.Set("policy_pack", policyPack)
+	d.Set("policy_pack", resolvedPolicyPackId)
 	return nil
 }
 
@@ -104,6 +128,10 @@ func resourceTurbotPolicyPackAttachmentRead(d *schema.ResourceData, meta interfa
 	if err := storeAkas(turbotResource.Turbot.Id, "resource_akas", d, meta); err != nil {
 		return err
 	}
+	// set policy_pack_akas property for DiffSuppressFunc
+	if err := storeAkas(policyPack, "policy_pack_akas", d, meta); err != nil {
+		return err
+	}
 	// assign results directly back into ResourceData
 	d.Set("resource", resource)
 	d.Set("policy_pack", policyPack)
@@ -112,7 +140,11 @@ func resourceTurbotPolicyPackAttachmentRead(d *schema.ResourceData, meta interfa
 
 func resourceTurbotPolicyPackAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*apiClient.Client)
-	input := mapFromResourceDataWithPropertyMap(d, policyPackAttachProperties)
+	policyPack, resource := parsePolicyPackId(d.Id())
+	input := map[string]interface{}{
+		"resource":     resource,
+		"smartFolders": policyPack,
+	}
 	err := client.DeleteSmartFolderAttachment(input)
 	if err != nil {
 		return err

--- a/turbot/resource_turbot_policy_pack_attachment_test.go
+++ b/turbot/resource_turbot_policy_pack_attachment_test.go
@@ -48,6 +48,46 @@ resource "turbot_policy_pack_attachment" "test" {
 `
 }
 
+func TestAccPolicyPackAttachment_Aka(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPolicyPackAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyPackAttachmentAkaConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyPackAttachmentExists("turbot_policy_pack_attachment.test_aka"),
+				),
+			},
+		},
+	})
+}
+
+// configs
+func testAccPolicyPackAttachmentAkaConfig() string {
+	return `
+resource "turbot_folder" "test_aka" {
+  parent      = "tmod:@turbot/turbot#/"
+  title       = "provider_test_aka"
+  description = "test folder for aka attachment"
+}
+
+resource "turbot_policy_pack" "test_aka" {
+  filter      = "resourceType:181381985925765 $.turbot.tags.a:b"
+  description = "Policy Pack AKA Testing"
+  title       = "policy_pack_aka"
+  akas        = ["test_policy_pack_aka_acceptance"]
+}
+
+resource "turbot_policy_pack_attachment" "test_aka" {
+  resource    = turbot_folder.test_aka.id
+  policy_pack = "test_policy_pack_aka_acceptance"
+  depends_on  = [turbot_policy_pack.test_aka]
+}
+`
+}
+
 // helper functions
 func testAccCheckPolicyPackAttachmentExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {

--- a/turbot/resource_turbot_smart_folder_attachment.go
+++ b/turbot/resource_turbot_smart_folder_attachment.go
@@ -7,11 +7,6 @@ import (
 	"strings"
 )
 
-var smartFolderAttachProperties = map[string]string{
-	"resource":     "resource",
-	"smart_folder": "smartFolders",
-}
-
 func resourceTurbotSmartFolderAttachemnt() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTurbotSmartFolderAttachmentCreate,
@@ -29,11 +24,21 @@ func resourceTurbotSmartFolderAttachemnt() *schema.Resource {
 				DiffSuppressFunc: suppressIfAkaMatches("resource_akas"),
 			},
 			"smart_folder": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppressIfAkaMatches("smart_folder_akas"),
 			},
 			"resource_akas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			// Stores the smart folder's AKAs so suppressIfAkaMatches can suppress diffs
+			// when the user provides an AKA but the state holds the resolved numeric ID.
+			"smart_folder_akas": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Schema{
@@ -71,22 +76,41 @@ func resourceTurbotSmartFolderAttachmentCreate(d *schema.ResourceData, meta inte
 	client := meta.(*apiClient.Client)
 	resource := d.Get("resource").(string)
 	smartFolder := d.Get("smart_folder").(string)
-	input := mapFromResourceDataWithPropertyMap(d, smartFolderAttachProperties)
 
-	_, err := client.CreateSmartFolderAttachment(input)
+	// Resolve the smart_folder AKA or ID to its numeric Turbot ID.
+	// The attachSmartFolders mutation requires numeric IDs — AKA strings cause "not eligible for attachment" errors.
+	// ReadResource uses a typed turbot { id } query which correctly populates Turbot.Id,
+	// unlike ReadSmartFolder which uses get(path:"turbot") and does not parse Id reliably.
+	sfResource, err := client.ReadResource(smartFolder, nil)
+	if err != nil {
+		return fmt.Errorf("error reading smart folder %q: %s", smartFolder, err.Error())
+	}
+	resolvedSmartFolderId := sfResource.Turbot.Id
+
+	input := map[string]interface{}{
+		"resource":     resource,
+		"smartFolders": resolvedSmartFolderId,
+	}
+
+	_, err = client.CreateSmartFolderAttachment(input)
 	if err != nil {
 		return err
 	}
 
-	// set resource_akas property by loading resource and fetching the akas
+	// Store resource AKAs for DiffSuppressFunc on the resource field
 	if err := storeAkas(resource, "resource_akas", d, meta); err != nil {
 		return err
 	}
-	// assign the id
-	var stateId = buildId(smartFolder, resource)
-	d.SetId(stateId)
+	// Store smart folder AKAs for DiffSuppressFunc on the smart_folder field
+	if err := storeAkas(resolvedSmartFolderId, "smart_folder_akas", d, meta); err != nil {
+		return err
+	}
+
+	// Always store the resolved numeric ID in state and the state ID so parseSmartFolderId
+	// (which splits on the first underscore) works correctly for all input formats.
+	d.SetId(buildId(resolvedSmartFolderId, resource))
 	d.Set("resource", resource)
-	d.Set("smart_folder", smartFolder)
+	d.Set("smart_folder", resolvedSmartFolderId)
 	return nil
 }
 
@@ -103,6 +127,10 @@ func resourceTurbotSmartFolderAttachmentRead(d *schema.ResourceData, meta interf
 	if err := storeAkas(turbotResource.Turbot.Id, "resource_akas", d, meta); err != nil {
 		return err
 	}
+	// set smart_folder_akas property for DiffSuppressFunc
+	if err := storeAkas(smartFolder, "smart_folder_akas", d, meta); err != nil {
+		return err
+	}
 	// assign results directly back into ResourceData
 	d.Set("resource", resource)
 	d.Set("smart_folder", smartFolder)
@@ -111,7 +139,11 @@ func resourceTurbotSmartFolderAttachmentRead(d *schema.ResourceData, meta interf
 
 func resourceTurbotSmartFolderAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*apiClient.Client)
-	input := mapFromResourceDataWithPropertyMap(d, smartFolderAttachProperties)
+	smartFolder, resource := parseSmartFolderId(d.Id())
+	input := map[string]interface{}{
+		"resource":     resource,
+		"smartFolders": smartFolder,
+	}
 	err := client.DeleteSmartFolderAttachment(input)
 	if err != nil {
 		return err
@@ -136,6 +168,6 @@ func buildId(smartFolder, resource string) string {
 func parseSmartFolderId(id string) (smartFolder, resource string) {
 	segments := strings.Split(id, "_")
 	smartFolder = segments[0]
-	resource = segments[1]
+	resource = strings.Join(segments[1:], "_")
 	return
 }

--- a/turbot/resource_turbot_smart_folder_attachment.go
+++ b/turbot/resource_turbot_smart_folder_attachment.go
@@ -79,13 +79,16 @@ func resourceTurbotSmartFolderAttachmentCreate(d *schema.ResourceData, meta inte
 
 	// Resolve the smart_folder AKA or ID to its numeric Turbot ID.
 	// The attachSmartFolders mutation requires numeric IDs — AKA strings cause "not eligible for attachment" errors.
-	// ReadResource uses a typed turbot { id } query which correctly populates Turbot.Id,
-	// unlike ReadSmartFolder which uses get(path:"turbot") and does not parse Id reliably.
+	// ReadSmartFolder unmarshals directly to a typed struct and does not reliably populate Turbot.Id;
+	// ReadResource decodes via mapstructure from interface{} which handles it correctly.
 	sfResource, err := client.ReadResource(smartFolder, nil)
 	if err != nil {
 		return fmt.Errorf("error reading smart folder %q: %s", smartFolder, err.Error())
 	}
 	resolvedSmartFolderId := sfResource.Turbot.Id
+	if resolvedSmartFolderId == "" {
+		return fmt.Errorf("smart folder %q resolved to an empty ID", smartFolder)
+	}
 
 	input := map[string]interface{}{
 		"resource":     resource,
@@ -101,10 +104,12 @@ func resourceTurbotSmartFolderAttachmentCreate(d *schema.ResourceData, meta inte
 	if err := storeAkas(resource, "resource_akas", d, meta); err != nil {
 		return err
 	}
-	// Store smart folder AKAs for DiffSuppressFunc on the smart_folder field
-	if err := storeAkas(resolvedSmartFolderId, "smart_folder_akas", d, meta); err != nil {
-		return err
+	// Reuse AKAs from the already-fetched smart folder resource to avoid a second round-trip
+	smartFolderAkas := sfResource.Turbot.Akas
+	if smartFolderAkas == nil {
+		smartFolderAkas = []string{resolvedSmartFolderId}
 	}
+	d.Set("smart_folder_akas", smartFolderAkas)
 
 	// Always store the resolved numeric ID in state and the state ID so parseSmartFolderId
 	// (which splits on the first underscore) works correctly for all input formats.

--- a/website/docs/r/policy_pack_attachment.html.markdown
+++ b/website/docs/r/policy_pack_attachment.html.markdown
@@ -57,8 +57,8 @@ The above example attaches a policy pack (`policy_pack`) to a resource (`my_reso
 
 The following arguments are supported:
 
-- `policy_pack` - (Required) The id of the policy pack to be attached.
-- `resource` - (Required) The id of the resource to which a policy pack will be attached.
+- `policy_pack` - (Required) The id or AKA of the policy pack to be attached.
+- `resource` - (Required) The id or AKA of the resource to which a policy pack will be attached.
 
 ## Attributes Reference
 

--- a/website/docs/r/smart_folder_attachment.html.markdown
+++ b/website/docs/r/smart_folder_attachment.html.markdown
@@ -60,8 +60,8 @@ The above example attaches a smart folder (`smart_folder`) to a resource (`my_re
 
 The following arguments are supported:
 
-- `resource` - (Required) The id of the resource to which a smart folder will be attached.
-- `smart_folder` - (Required) The id of the smart folder to be attached.
+- `resource` - (Required) The id or AKA of the resource to which a smart folder will be attached.
+- `smart_folder` - (Required) The id or AKA of the smart folder to be attached.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #240

## Summary

- `turbot_policy_pack_attachment`: `policy_pack` now accepts AKA strings in addition to numeric Turbot IDs. Resolves AKA to numeric ID via `ReadResource` before calling `attachSmartFolders`. Adds `policy_pack_akas` computed attribute and `DiffSuppressFunc` to suppress spurious plan diffs.
- `turbot_smart_folder_attachment`: same fix for `smart_folder` field, adds `smart_folder_akas` computed attribute. Also fixes `parseSmartFolderId` to use `strings.Join(segments[1:], "_")` for correctness when resource IDs contain underscores.

## Root cause

The `attachSmartFolders` GraphQL mutation requires a numeric Turbot ID for `smartFolders`. Passing an AKA string returns `smart folder ids not eligible for attachment`. The old code passed the field value directly without resolving it first.

## Test plan

- [x] policy_pack=AKA, resource=AKA → attach + destroy OK
- [x] policy_pack=AKA, resource=numericID → attach + destroy OK
- [x] policy_pack=numericID, resource=AKA → attach + destroy OK
- [x] policy_pack=numericID, resource=numericID → attach + destroy OK
- [x] Second plan after apply shows no diff (DiffSuppressFunc working)

All 4 combinations verified against a live Turbot Guardrails workspace.

Generated with [Claude Code](https://claude.com/claude-code)