### PR TITLE
Turbot Terraform Provider 1.13.3. Closes #242

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.13.3 (Unreleased)
+## 1.13.3 (May 4, 2026)
 
 BUG FIXES:
 


### PR DESCRIPTION
## Summary

- Finalize CHANGELOG date for 1.13.3 release: `(Unreleased)` → `(May 4, 2026)`.
- Closes #242.

Includes the AKA-support fix from #241 (`turbot_policy_pack_attachment` and `turbot_smart_folder_attachment` now accept AKA strings, resolving them to numeric Turbot IDs before calling `attachSmartFolders`).

## Test plan

- [ ] Merge → tag `v1.13.3` on master → release workflow runs goreleaser → GitHub release published with 16 signed assets
- [ ] Verify provider appears at https://registry.terraform.io/providers/turbot/turbot/latest within ~30 min of release

🤖 Generated with [Claude Code](https://claude.com/claude-code)